### PR TITLE
Create ChatGPT-like UI

### DIFF
--- a/components/App.tsx
+++ b/components/App.tsx
@@ -1,0 +1,16 @@
+import React from 'react'
+import Sidebar from './Sidebar'
+import ChatArea from './ChatArea'
+import ProductPanel from './ProductPanel'
+
+export default function App() {
+  return (
+    <div className="flex h-screen">
+      <Sidebar />
+      <div className="flex-1 flex flex-col">
+        <ChatArea messages={[]} />
+      </div>
+      <ProductPanel />
+    </div>
+  )
+}

--- a/components/ChatArea.tsx
+++ b/components/ChatArea.tsx
@@ -91,40 +91,42 @@ export default function ChatArea({ messages }: { messages: any[] }) {
   }, [chatMessages]);
 
   return (
-    <div className="flex flex-col h-full overflow-y-auto px-4 py-6 space-y-4">
-      {chatMessages.map((msg, index) => (
-        <ChatBubble key={index} from={msg.from} text={msg.text} />
-      ))}
+    <div className="flex flex-col h-full bg-gray-100 dark:bg-gray-900">
+      <div className="flex-1 overflow-y-auto px-4 py-6 space-y-4 bg-white dark:bg-gray-800">
+        {chatMessages.map((msg, index) => (
+          <ChatBubble key={index} from={msg.from} text={msg.text} />
+        ))}
 
-      {currentQuestionIndex < philosophyQuestions.length && (
-        <PhilosophyQuestion
-          question={philosophyQuestions[currentQuestionIndex]}
-          onNext={handleSelection}
-        />
-      )}
+        {currentQuestionIndex < philosophyQuestions.length && (
+          <PhilosophyQuestion
+            question={philosophyQuestions[currentQuestionIndex]}
+            onNext={handleSelection}
+          />
+        )}
+
+        {showProductSuggestions && <ProductSuggestions products={products} />}
+
+        <div ref={chatEndRef} />
+      </div>
 
       {showChatInput && (
-        <div className="flex gap-2 items-center border-t pt-4">
+        <div className="border-t border-gray-300 dark:border-gray-700 p-4 flex gap-2 items-center bg-white dark:bg-gray-800">
           <input
             type="text"
-            className="flex-1 border px-3 py-2 rounded"
+            className="flex-1 border px-3 py-2 rounded bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
             value={input}
             onChange={(e) => setInput(e.target.value)}
-            onKeyDown={(e) => e.key === "Enter" && handleSend()}
+            onKeyDown={(e) => e.key === 'Enter' && handleSend()}
             placeholder="Type your message..."
           />
           <button
             onClick={handleSend}
-            className="bg-blue-500 text-white px-4 py-2 rounded hover:bg-blue-600"
+            className="bg-green-600 text-white px-4 py-2 rounded hover:bg-green-700"
           >
             Send
           </button>
         </div>
       )}
-
-      {showProductSuggestions && <ProductSuggestions products={products} />}
-
-      <div ref={chatEndRef} />
     </div>
   );
 }

--- a/components/ChatBubble.tsx
+++ b/components/ChatBubble.tsx
@@ -10,16 +10,10 @@ export const ChatBubble = ({
   const isUser = from === "user";
 
   return (
-    <div
-      className={`w-full flex ${
-        isUser ? "justify-end" : "justify-start"
-      }`}
-    >
+    <div className={`w-full flex ${isUser ? "justify-end" : "justify-start"} mb-3`}>
       <div
-        className={`max-w-xs px-4 py-2 rounded-lg shadow ${
-          isUser
-            ? "bg-blue-500 text-white"
-            : "bg-gray-200 text-gray-800"
+        className={`max-w-2xl px-4 py-2 rounded-lg whitespace-pre-wrap ${
+          isUser ? "bg-blue-500 text-white" : "bg-gray-100 text-gray-800"
         }`}
       >
         {text}

--- a/components/ProductPanel.tsx
+++ b/components/ProductPanel.tsx
@@ -37,20 +37,20 @@ const mockProducts: Product[] = [
 
 export default function ProductPanel() {
   return (
-    <div className="h-full w-80 bg-white border-l p-4 space-y-4 overflow-y-auto">
+    <div className="h-full w-80 bg-gray-50 dark:bg-gray-800 border-l p-4 space-y-4 overflow-y-auto">
       <h2 className="text-lg font-semibold mb-2">Suggested Products</h2>
 
       {mockProducts.map((p) => (
         <div
           key={p.id}
-          className="border rounded-xl p-4 shadow-sm hover:shadow-md transition"
+          className="border rounded-xl p-4 shadow-sm hover:shadow-md transition bg-white dark:bg-gray-700"
         >
-          <div className="text-sm text-gray-500 mb-1">
+          <div className="text-sm text-gray-500 dark:text-gray-300 mb-1">
             Type {p.type}
           </div>
           <div className="font-bold mb-1">{p.title}</div>
-          <div className="text-sm text-gray-700 mb-2">{p.description}</div>
-          <div className="text-xs text-gray-400 mb-1">
+          <div className="text-sm text-gray-700 dark:text-gray-200 mb-2">{p.description}</div>
+          <div className="text-xs text-gray-400 dark:text-gray-300 mb-1">
             Tags: {p.tags.join(', ')}
           </div>
           <div className="text-xs text-blue-700 font-semibold">

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -18,11 +18,11 @@ export default function Sidebar() {
   }
 
   return (
-    <div className="h-full w-64 bg-gray-100 border-r flex flex-col">
-      <div className="p-4 border-b">
+    <div className="h-full w-64 bg-gray-900 text-gray-100 border-r flex flex-col">
+      <div className="p-4 border-b border-gray-700">
         <button
           onClick={handleNewThread}
-          className="w-full px-3 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
+          className="w-full px-3 py-2 bg-green-600 text-white rounded hover:bg-green-700"
         >
           {'+ New Thread'}
         </button>
@@ -35,8 +35,8 @@ export default function Sidebar() {
             onClick={() => setActiveId(thread.id)}
             className={`px-4 py-2 cursor-pointer ${
               thread.id === activeId
-                ? 'bg-blue-100 text-blue-800 font-semibold'
-                : 'hover:bg-gray-200'
+                ? 'bg-gray-700 text-white font-semibold'
+                : 'hover:bg-gray-800'
             }`}
           >
             {thread.title}


### PR DESCRIPTION
## Summary
- add App layout assembling sidebar, chat area, and product panel
- restyle components to resemble ChatGPT
- adjust ChatArea with fixed input and dark mode colors
- tweak Sidebar and ProductPanel styles for dark theme
- widen chat bubbles and preserve formatting

## Testing
- `npm test` *(fails: could not find package.json)*